### PR TITLE
Using a name prefix instead of name for template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@
 resource "google_compute_instance_template" "default" {
   count   = "${var.module_enabled ? 1 : 0}"
   project = "${var.project}"
-  name    = "${random_id.rand.dec}"
+  name_prefix = "${random_id.rand.dec}"
 
   machine_type = "${var.machine_type}"
 


### PR DESCRIPTION
## Problem:

When modifying anything in the instance template, for example, the machine type, it is unable to make this modification in terraform because of a duplicate named resource.  Using the lifecycle rule "create before destroy" is necessary, but because of this, there can not be two similarly named templates.  Eg:

`* google_compute_instance_template.default: Error creating instance template: googleapi: Error 409: The resource 'projects/projectname/global/instanceTemplates/default-7850850885292525658' already exists`

## Solution:

There is a feature called "name_prefix" instead of "name" which helps fix this use-case.  This merge implements it.